### PR TITLE
Update license to LGPL

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,172 +1,155 @@
-Academic Free License ("AFL") v. 3.0
+GNU LESSER GENERAL PUBLIC LICENSE
+Version 3, 29 June 2007
 
-This Academic Free License (the "License") applies to any original work of
-authorship (the "Original Work") whose owner (the "Licensor") has placed the
-following licensing notice adjacent to the copyright notice for the Original
-Work:
+Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
 
-     Licensed under the Academic Free License version 3.0
+Everyone is permitted to copy and distribute verbatim copies of this license
+document, but changing it is not allowed.
 
-1) Grant of Copyright License. Licensor grants You a worldwide, royalty-free,
-non-exclusive, sublicensable license, for the duration of the copyright, to do
-the following:
+This version of the GNU Lesser General Public License incorporates the terms
+and conditions of version 3 of the GNU General Public License, supplemented
+by the additional permissions listed below.
 
-     a) to reproduce the Original Work in copies, either alone or as part of a
-     collective work;
+0. Additional Definitions.
 
-     b) to translate, adapt, alter, transform, modify, or arrange the Original
-     Work, thereby creating derivative works ("Derivative Works") based upon
-     the Original Work;
+As used herein, “this License” refers to version 3 of the GNU Lesser General
+Public License, and the “GNU GPL” refers to version 3 of the
+GNU General Public License.
 
-     c) to distribute or communicate copies of the Original Work and
-     Derivative Works to the public, under any license of your choice that
-     does not contradict the terms and conditions, including Licensor's
-     reserved rights and remedies, in this Academic Free License;
+“The Library” refers to a covered work governed by this License, other than
+an Application or a Combined Work as defined below.
 
-     d) to perform the Original Work publicly; and
+An “Application” is any work that makes use of an interface provided by the
+Library, but which is not otherwise based on the Library. Defining a subclass
+of a class defined by the Library is deemed a mode of using an interface
+provided by the Library.
 
-     e) to display the Original Work publicly.
+A “Combined Work” is a work produced by combining or linking an Application
+with the Library. The particular version of the Library with which the
+Combined Work was made is also called the “Linked Version”.
 
-2) Grant of Patent License. Licensor grants You a worldwide, royalty-free,
-non-exclusive, sublicensable license, under patent claims owned or controlled
-by the Licensor that are embodied in the Original Work as furnished by the
-Licensor, for the duration of the patents, to make, use, sell, offer for sale,
-have made, and import the Original Work and Derivative Works.
+The “Minimal Corresponding Source” for a Combined Work means the Corresponding
+Source for the Combined Work, excluding any source code for portions of the
+Combined Work that, considered in isolation, are based on the Application,
+and not on the Linked Version.
 
-3) Grant of Source Code License. The term "Source Code" means the preferred
-form of the Original Work for making modifications to it and all available
-documentation describing how to modify the Original Work. Licensor agrees to
-provide a machine-readable copy of the Source Code of the Original Work along
-with each copy of the Original Work that Licensor distributes. Licensor
-reserves the right to satisfy this obligation by placing a machine-readable
-copy of the Source Code in an information repository reasonably calculated to
-permit inexpensive and convenient access by You for as long as Licensor
-continues to distribute the Original Work.
+The “Corresponding Application Code” for a Combined Work means the object code
+and/or source code for the Application, including any data and utility programs
+needed for reproducing the Combined Work from the Application, but excluding
+the System Libraries of the Combined Work.
 
-4) Exclusions From License Grant. Neither the names of Licensor, nor the names
-of any contributors to the Original Work, nor any of their trademarks or
-service marks, may be used to endorse or promote products derived from this
-Original Work without express prior permission of the Licensor. Except as
-expressly stated herein, nothing in this License grants any license to
-Licensor's trademarks, copyrights, patents, trade secrets or any other
-intellectual property. No patent license is granted to make, use, sell, offer
-for sale, have made, or import embodiments of any patent claims other than the
-licensed claims defined in Section 2. No license is granted to the trademarks
-of Licensor even if such marks are included in the Original Work. Nothing in
-this License shall be interpreted to prohibit Licensor from licensing under
-terms different from this License any Original Work that Licensor otherwise
-would have a right to license.
+1. Exception to Section 3 of the GNU GPL.
 
-5) External Deployment. The term "External Deployment" means the use,
-distribution, or communication of the Original Work or Derivative Works in any
-way such that the Original Work or Derivative Works may be used by anyone
-other than You, whether those works are distributed or communicated to those
-persons or made available as an application intended for use over a network.
-As an express condition for the grants of license hereunder, You must treat
-any External Deployment by You of the Original Work or a Derivative Work as a
-distribution under section 1(c).
+You may convey a covered work under sections 3 and 4 of this License without
+being bound by section 3 of the GNU GPL.
 
-6) Attribution Rights. You must retain, in the Source Code of any Derivative
-Works that You create, all copyright, patent, or trademark notices from the
-Source Code of the Original Work, as well as any notices of licensing and any
-descriptive text identified therein as an "Attribution Notice." You must cause
-the Source Code for any Derivative Works that You create to carry a prominent
-Attribution Notice reasonably calculated to inform recipients that You have
-modified the Original Work.
+2. Conveying Modified Versions.
 
-7) Warranty of Provenance and Disclaimer of Warranty. Licensor warrants that
-the copyright in and to the Original Work and the patent rights granted herein
-by Licensor are owned by the Licensor or are sublicensed to You under the
-terms of this License with the permission of the contributor(s) of those
-copyrights and patent rights. Except as expressly stated in the immediately
-preceding sentence, the Original Work is provided under this License on an "AS
-IS" BASIS and WITHOUT WARRANTY, either express or implied, including, without
-limitation, the warranties of non-infringement, merchantability or fitness for
-a particular purpose. THE ENTIRE RISK AS TO THE QUALITY OF THE ORIGINAL WORK
-IS WITH YOU. This DISCLAIMER OF WARRANTY constitutes an essential part of this
-License. No license to the Original Work is granted by this License except
-under this disclaimer.
+If you modify a copy of the Library, and, in your modifications, a facility
+refers to a function or data to be supplied by an Application that uses the
+facility (other than as an argument passed when the facility is invoked),
+then you may convey a copy of the modified version:
 
-8) Limitation of Liability. Under no circumstances and under no legal theory,
-whether in tort (including negligence), contract, or otherwise, shall the
-Licensor be liable to anyone for any indirect, special, incidental, or
-consequential damages of any character arising as a result of this License or
-the use of the Original Work including, without limitation, damages for loss
-of goodwill, work stoppage, computer failure or malfunction, or any and all
-other commercial damages or losses. This limitation of liability shall not
-apply to the extent applicable law prohibits such limitation.
+    a) under this License, provided that you make a good faith effort to
+    ensure that, in the event an Application does not supply the function or
+    data, the facility still operates, and performs whatever part of its
+    purpose remains meaningful, or
 
-9) Acceptance and Termination. If, at any time, You expressly assented to this
-License, that assent indicates your clear and irrevocable acceptance of this
-License and all of its terms and conditions. If You distribute or communicate
-copies of the Original Work or a Derivative Work, You must make a reasonable
-effort under the circumstances to obtain the express assent of recipients to
-the terms of this License. This License conditions your rights to undertake
-the activities listed in Section 1, including your right to create Derivative
-Works based upon the Original Work, and doing so without honoring these terms
-and conditions is prohibited by copyright law and international treaty.
-Nothing in this License is intended to affect copyright exceptions and
-limitations (including "fair use" or "fair dealing"). This License shall
-terminate immediately and You may no longer exercise any of the rights granted
-to You by this License upon your failure to honor the conditions in Section
-1(c).
+    b) under the GNU GPL, with none of the additional permissions of this
+    License applicable to that copy.
 
-10) Termination for Patent Action. This License shall terminate automatically
-and You may no longer exercise any of the rights granted to You by this
-License as of the date You commence an action, including a cross-claim or
-counterclaim, against Licensor or any licensee alleging that the Original Work
-infringes a patent. This termination provision shall not apply for an action
-alleging patent infringement by combinations of the Original Work with other
-software or hardware.
+3. Object Code Incorporating Material from Library Header Files.
 
-11) Jurisdiction, Venue and Governing Law. Any action or suit relating to this
-License may be brought only in the courts of a jurisdiction wherein the
-Licensor resides or in which Licensor conducts its primary business, and under
-the laws of that jurisdiction excluding its conflict-of-law provisions. The
-application of the United Nations Convention on Contracts for the
-International Sale of Goods is expressly excluded. Any use of the Original
-Work outside the scope of this License or after its termination shall be
-subject to the requirements and penalties of copyright or patent law in the
-appropriate jurisdiction. This section shall survive the termination of this
-License.
+The object code form of an Application may incorporate material from a header
+file that is part of the Library. You may convey such object code under terms
+of your choice, provided that, if the incorporated material is not limited to
+numerical parameters, data structure layouts and accessors, or small macros,
+inline functions and templates (ten or fewer lines in length),
+you do both of the following:
 
-12) Attorneys' Fees. In any action to enforce the terms of this License or
-seeking damages relating thereto, the prevailing party shall be entitled to
-recover its costs and expenses, including, without limitation, reasonable
-attorneys' fees and costs incurred in connection with such action, including
-any appeal of such action. This section shall survive the termination of this
-License.
+    a) Give prominent notice with each copy of the object code that the Library
+    is used in it and that the Library and its use are covered by this License.
 
-13) Miscellaneous. If any provision of this License is held to be
-unenforceable, such provision shall be reformed only to the extent necessary
-to make it enforceable.
+    b) Accompany the object code with a copy of the GNU GPL
+    and this license document.
 
-14) Definition of "You" in This License. "You" throughout this License,
-whether in upper or lower case, means an individual or a legal entity
-exercising rights under, and complying with all of the terms of, this License.
-For legal entities, "You" includes any entity that controls, is controlled by,
-or is under common control with you. For purposes of this definition,
-"control" means (i) the power, direct or indirect, to cause the direction or
-management of such entity, whether by contract or otherwise, or (ii) ownership
-of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial
-ownership of such entity.
+4. Combined Works.
 
-15) Right to Use. You may use the Original Work in all ways not otherwise
-restricted or conditioned by this License or by law, and Licensor promises not
-to interfere with or be responsible for such uses by You.
+You may convey a Combined Work under terms of your choice that, taken together,
+effectively do not restrict modification of the portions of the Library
+contained in the Combined Work and reverse engineering for debugging such
+modifications, if you also do each of the following:
 
-16) Modification of This License. This License is Copyright © 2005 Lawrence
-Rosen. Permission is granted to copy, distribute, or communicate this License
-without modification. Nothing in this License permits You to modify this
-License as applied to the Original Work or to Derivative Works. However, You
-may modify the text of this License and copy, distribute or communicate your
-modified version (the "Modified License") and apply it to other original works
-of authorship subject to the following conditions: (i) You may not indicate in
-any way that your Modified License is the "Academic Free License" or "AFL" and
-you may not use those names in the name of your Modified License; (ii) You
-must replace the notice specified in the first paragraph above with the notice
-"Licensed under <insert your license name here>" or with a notice of your own
-that is not confusingly similar to the notice in this License; and (iii) You
-may not claim that your original works are open source software unless your
-Modified License has been approved by Open Source Initiative (OSI) and You
-comply with its license review and certification process.
+    a) Give prominent notice with each copy of the Combined Work that the
+    Library is used in it and that the Library and its use are covered
+    by this License.
+
+    b) Accompany the Combined Work with a copy of the GNU GPL and
+    this license document.
+
+    c) For a Combined Work that displays copyright notices during execution,
+    include the copyright notice for the Library among these notices, as well
+    as a reference directing the user to the copies of the GNU GPL
+    and this license document.
+
+    d) Do one of the following:
+
+        0) Convey the Minimal Corresponding Source under the terms of this
+        License, and the Corresponding Application Code in a form suitable
+        for, and under terms that permit, the user to recombine or relink
+        the Application with a modified version of the Linked Version to
+        produce a modified Combined Work, in the manner specified by section 6
+        of the GNU GPL for conveying Corresponding Source.
+
+        1) Use a suitable shared library mechanism for linking with the
+        Library. A suitable mechanism is one that (a) uses at run time a
+        copy of the Library already present on the user's computer system,
+        and (b) will operate properly with a modified version of the Library
+        that is interface-compatible with the Linked Version.
+
+    e) Provide Installation Information, but only if you would otherwise be
+    required to provide such information under section 6 of the GNU GPL, and
+    only to the extent that such information is necessary to install and
+    execute a modified version of the Combined Work produced by recombining
+    or relinking the Application with a modified version of the Linked Version.
+    (If you use option 4d0, the Installation Information must accompany the
+    Minimal Corresponding Source and Corresponding Application Code. If you
+    use option 4d1, you must provide the Installation Information in the
+    manner specified by section 6 of the GNU GPL for
+    conveying Corresponding Source.)
+
+5. Combined Libraries.
+
+You may place library facilities that are a work based on the Library side by
+side in a single library together with other library facilities that are not
+Applications and are not covered by this License, and convey such a combined
+library under terms of your choice, if you do both of the following:
+
+    a) Accompany the combined library with a copy of the same work based on
+    the Library, uncombined with any other library facilities, conveyed under
+    the terms of this License.
+
+    b) Give prominent notice with the combined library that part of it is a
+    work based on the Library, and explaining where to find the accompanying
+    uncombined form of the same work.
+
+6. Revised Versions of the GNU Lesser General Public License.
+
+The Free Software Foundation may publish revised and/or new versions of the
+GNU Lesser General Public License from time to time. Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number. If the Library as you
+received it specifies that a certain numbered version of the GNU Lesser
+General Public License “or any later version” applies to it, you have the
+option of following the terms and conditions either of that published version
+or of any later version published by the Free Software Foundation. If the
+Library as you received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser General
+Public License ever published by the Free Software Foundation.
+
+If the Library as you received it specifies that a proxy can decide whether
+future versions of the GNU Lesser General Public License shall apply, that
+proxy's public statement of acceptance of any version is permanent
+authorization for you to choose that version for the Library.


### PR DESCRIPTION
Update license to LGPL. Upstream source is now MIT-licensed (no longer Academic Free License, which required derivatives to use the same license). 

I don't want to go full MIT, as I would like you to give credit to the pyCUFSM open-source project if you use it and I don't want to see anyone trying to sell pyCUFSM on its own without adding meaningful additional value beyond it. However, I'm otherwise happy and excited for this library to be used anywhere it can reasonably be within other systems (either other open-source projects or commercial ventures). 